### PR TITLE
Update doc building process to handle lfs

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -38,6 +38,4 @@ jobs:
           git add --all .
           git commit -m "Deploying from @ $GITHUB_SHA 🚀"
 
-          git lfs migrate export --include="*"
-
           git push -f

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git clone -b $PAGES_BRANCH https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git gh-pages-deployment-folder
-          rsync -q -av --checksum --progress $SITE_DIR/. gh-pages-deployment-folder --exclude .ssh --exclude .git --exclude .github --exclude '*.gz'
+          rsync -q -av --checksum --progress $SITE_DIR/. gh-pages-deployment-folder --delete --exclude .ssh --exclude .git --exclude .github --exclude '*.gz'
 
           cd gh-pages-deployment-folder
           git config user.name $GITHUB_ACTOR

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+          lfs: true
 
       - name: Pull docker image 🐳
         run: docker pull cmsml/documentation


### PR DESCRIPTION
I looked at the gh workflow triggered by https://github.com/JamesIves/github-pages-deploy-action/issues/373, and dug in a bit.

The problems with lfs here are actually that the checkout action doesn't check out lfs by default. Once one does that, there's no need to handle lfs as part of the deployment.

And I added a `--delete` to `rsync` to get rid of old files (including `.gitattributes`).

I've enabled automation on my fork, the resulting update to gh-pages is https://github.com/cms-ml/documentation/compare/gh-pages...Pike:gh-pages, and https://pike.github.io/documentation-1/inference/performance.html works as expected.

To folks looking at this in the future, the links are probably gonna break at some point in the future, when my fork changes or goes away.