### PR TITLE
Enable LaTeX Rendering

### DIFF
--- a/content/javascripts/mathjax.js
+++ b/content/javascripts/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => { 
+  MathJax.typesetPromise()
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,8 @@ markdown_extensions:
   - markdown.extensions.meta
   - markdown.extensions.toc:
       permalink: true
-  - pymdownx.arithmatex
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.betterem:
       smart_enable: all
   - pymdownx.caret
@@ -72,6 +73,9 @@ markdown_extensions:
 
 extra_javascript:
   - https://unpkg.com/mermaid@8.6/dist/mermaid.min.js
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra:
   FOO: BAR


### PR DESCRIPTION
Add options/extensions/externals to MkDocs which allow for LaTeX rendering.

This configuration was suggested from https://squidfunk.github.io/mkdocs-material/reference/mathjax/. It has been tested and seem to work when using the environments:
- `$<LaTeX code>$`
- `$$<LaTeX code>$$`

It doesn't appear to adversely affect any of the existing markdown documents.