### PR TITLE
Update tf2 inference docs.

### DIFF
--- a/content/inference/code/tensorflow/tensorflow2_mt_plugin.cpp
+++ b/content/inference/code/tensorflow/tensorflow2_mt_plugin.cpp
@@ -20,8 +20,9 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-  // an additional static method for initializing the global cache
+  // additional static methods for initializing and closing the global cache
   static std::unique_ptr<tensorflow::SessionCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(const tensorflow::SessionCache*);
 
 private:
   void beginJob();
@@ -46,6 +47,8 @@ std::unique_ptr<tensorflow::SessionCache> MyPlugin::initializeGlobalCache(const 
   }
   return std::make_unique<tensorflow::SessionCache>(graphPath, options);
 }
+
+void MyPlugin::globalEndJob(const tensorflow::SessionCache* cache) {}
 
 void MyPlugin::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // defining this function will lead to a *_cfi file being generated when compiling

--- a/content/inference/tensorflow1.md
+++ b/content/inference/tensorflow1.md
@@ -1,3 +1,0 @@
-# Direct inference with TensorFlow 1
-
-While it is technically still possible to use TensorFlow 1, this version of TensorFlow is quite old and is no longer supported by CMSSW. We highly recommend that you update your model to TensorFlow 2 and follow the integration guide in the [Inference/Direct inference/TensorFlow 2](tensorflow2.md) documentation.

--- a/content/inference/tensorflow2.md
+++ b/content/inference/tensorflow2.md
@@ -369,20 +369,22 @@ public:
     explicit GraphLoadingMT(const edm::ParameterSet&, const tensorflow::SessionCache*);
     ~GraphLoadingMT();
 
-    // an additional static method for initializing the global cache
+    // additional static methods for initializing and closing the global cache
     static std::unique_ptr<tensorflow::SessionCache> initializeGlobalCache(const edm::ParameterSet&);
-    static void globalEndJob(const CacheData*);
+    static void globalEndJob(const tensorflow::SessionCache*);
 ...
 ```
 
 Implement `initializeGlobalCache` to control the behavior of how the cache object is created.
-The destructor of `tensorflow::SessionCache` already handles the closing of the session itself and the deletion of all objects.
+You also need to implement `globalEndJob`, however, it can remain empty as the destructor of `tensorflow::SessionCache` already handles the closing of the session itself and the deletion of all objects.
 
 ```cpp
 std::unique_ptr<tensorflow::SessionCache> MyPlugin::initializeGlobalCache(const edm::ParameterSet& config) {
   std::string graphPath = edm::FileInPath(params.getParameter<std::string>("graphPath")).fullPath();
   return std::make_unique<tensorflow::SessionCache>(graphPath);
 }
+
+void MyPlugin::globalEndJob(const tensorflow::SessionCache* cache) {}
 ```
 
 ??? hint "Custom cache struct"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,7 +143,6 @@ nav:
       - After training: general_advice/after/after.md
     - Inference:
       - Direct inference:
-        - TensorFlow 1: inference/tensorflow1.md
         - TensorFlow 2: inference/tensorflow2.md
         - PyTorch: inference/pytorch.md
         - PyTorch Geometric: inference/pyg.md


### PR DESCRIPTION
Hi & happy new year,

this little PR adjusts the code examples in the tf v2 inference docs, where references and hints towards implementing a mandatory `globalEndJob()` static method were missing. And while I was on it, I removed the tf v1 documentation page, which was empty since day 1.